### PR TITLE
Feat アイテムフォーム 追加動作実装

### DIFF
--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -5,9 +5,7 @@ class SetlistsController < ApplicationController
 
   def new
     @setlist = Setlist.new
-    20.times do
-      @setlist.setlist_items.build
-    end
+    @setlist.setlist_items.build
   end
 
   def create

--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -16,7 +16,7 @@ class SetlistsController < ApplicationController
       flash[:success] = "セットリストを登録しました。"
       redirect_to setlists_path
     else
-      @setlist.setlist_items.build
+      @setlist.setlist_items.build if @setlist.setlist_items.empty?
       flash.now[:error] = "セットリストの登録に失敗しました。"
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -16,6 +16,7 @@ class SetlistsController < ApplicationController
       flash[:success] = "セットリストを登録しました。"
       redirect_to setlists_path
     else
+      @setlist.setlist_items.build
       flash.now[:error] = "セットリストの登録に失敗しました。"
       render :new, status: :unprocessable_entity
     end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "./customs/hello_world"
+import "./customs/setlist_form"

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./customs/hello_world"

--- a/app/javascript/customs/hello_world.js
+++ b/app/javascript/customs/hello_world.js
@@ -1,0 +1,3 @@
+document.addEventListener("DOMContentLoaded", (event) => {
+  console.log("Hello, World!");
+});

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -1,10 +1,15 @@
 let count = 0;
 
-document.addEventListener("DOMContentLoaded", (event) => {
+document.addEventListener("turbo:load", (event) => {
   console.log("セットリスト登録フォーム用js");
   const addItemButton = document.getElementById("add_setlist_item");
   const setlistItemContainer = document.getElementById("setlist_items_container");
   const itemForm = document.getElementById("template_setlist_item");
+
+  if (!addItemButton || !setlistItemContainer || !itemForm) {
+    console.log("必要な要素が見つかりません");
+    return;
+  }
 
   // 「曲を追加」ボタンにイベントを設定
   addItemButton.addEventListener("click", (event) => {

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -1,6 +1,7 @@
-let count = 0;
+document.addEventListener("turbo:render", setupAddItemButton, console.log("turbo:render"));
 
-document.addEventListener("turbo:load", (event) => {
+function setupAddItemButton() {
+  let count = 0;
   console.log("セットリスト登録フォーム用js");
   const addItemButton = document.getElementById("add_setlist_item");
   const setlistItemContainer = document.getElementById("setlist_items_container");
@@ -26,4 +27,4 @@ document.addEventListener("turbo:load", (event) => {
     count++;
     return count;
   }
-});
+};

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -7,8 +7,9 @@ document.addEventListener("DOMContentLoaded", (event) => {
   // 「曲を追加」ボタンにイベントを設定
   addItemButton.addEventListener("click", (event) => {
     console.log("楽曲追加ボタンが押された");
-    const newItemForm = document.getElementById("template_setlist_item");
-    console.log(newItemForm);
+    const itemForm = document.getElementById("template_setlist_item");
+    const itemFormClone = itemForm.children[0].cloneNode(true);
+    console.log(itemFormClone);
     counter();
     console.log(count);
   });

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -1,3 +1,5 @@
+let count = 0;
+
 document.addEventListener("DOMContentLoaded", (event) => {
   console.log("セットリスト登録フォーム用js");
   const addItemButton = document.getElementById("add_setlist_item");
@@ -7,5 +9,12 @@ document.addEventListener("DOMContentLoaded", (event) => {
     console.log("楽曲追加ボタンが押された");
     const newItemForm = document.getElementById("template_setlist_item");
     console.log(newItemForm);
+    counter();
+    console.log(count);
   });
+
+  function counter() {
+    count++;
+    return count;
+  }
 });

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -22,18 +22,17 @@ function setupAddItemButton() {
   }
 
   // 「曲を追加」ボタンにイベントを設定
-  addItemButton.addEventListener("click", addItemform);
-
-  function counter() {
-    count++;
-    return count;
-  }
-
-  function addItemform() {
+  addItemButton.addEventListener("click", () => {
+    counter();
     const itemFormClone = itemForm.children[0].cloneNode(true);
     itemFormClone.children[1].setAttribute("name", `setlist[setlist_items_attributes][${count}][song_title]`);
     itemFormClone.children[1].setAttribute("id", `setlist_setlist_items_attributes_${count}_song_title`);
     console.log(itemFormClone);
     setlistItemContainer.appendChild(itemFormClone);
+  });
+
+  function counter() {
+    count++;
+    return count;
   }
 };

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -13,6 +13,14 @@ function setupAddItemButton() {
     return;
   }
 
+  if (addItemButton.getAttribute("id") === "add_item_button") {
+    console.log("ボタンがすでに設定されています");
+    return;
+  } else {
+    console.log("ボタンが設定されていません");
+    addItemButton.setAttribute("id", "add_item_button");
+  }
+
   // 「曲を追加」ボタンにイベントを設定
   addItemButton.addEventListener("click", addItemform);
 

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -1,0 +1,11 @@
+document.addEventListener("DOMContentLoaded", (event) => {
+  console.log("セットリスト登録フォーム用js");
+  const addItemButton = document.getElementById("add_setlist_item");
+
+  // 「曲を追加」ボタンにイベントを設定
+  addItemButton.addEventListener("click", (event) => {
+    console.log("楽曲追加ボタンが押された");
+    const newItemForm = document.getElementById("template_setlist_item");
+    console.log(newItemForm);
+  });
+});

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -1,3 +1,4 @@
+document.addEventListener("turbo:load", setupAddItemButton, console.log("turbo:load"));
 document.addEventListener("turbo:render", setupAddItemButton, console.log("turbo:render"));
 
 function setupAddItemButton() {
@@ -13,18 +14,18 @@ function setupAddItemButton() {
   }
 
   // 「曲を追加」ボタンにイベントを設定
-  addItemButton.addEventListener("click", (event) => {
-    console.log("楽曲追加ボタンが押された");
-    counter();
+  addItemButton.addEventListener("click", addItemform);
+
+  function counter() {
+    count++;
+    return count;
+  }
+
+  function addItemform() {
     const itemFormClone = itemForm.children[0].cloneNode(true);
     itemFormClone.children[1].setAttribute("name", `setlist[setlist_items_attributes][${count}][song_title]`);
     itemFormClone.children[1].setAttribute("id", `setlist_setlist_items_attributes_${count}_song_title`);
     console.log(itemFormClone);
     setlistItemContainer.appendChild(itemFormClone);
-  });
-
-  function counter() {
-    count++;
-    return count;
   }
 };

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -3,15 +3,18 @@ let count = 0;
 document.addEventListener("DOMContentLoaded", (event) => {
   console.log("セットリスト登録フォーム用js");
   const addItemButton = document.getElementById("add_setlist_item");
+  const setlistItemContainer = document.getElementById("setlist_items_container");
+  const itemForm = document.getElementById("template_setlist_item");
 
   // 「曲を追加」ボタンにイベントを設定
   addItemButton.addEventListener("click", (event) => {
     console.log("楽曲追加ボタンが押された");
-    const itemForm = document.getElementById("template_setlist_item");
-    const itemFormClone = itemForm.children[0].cloneNode(true);
-    console.log(itemFormClone);
     counter();
-    console.log(count);
+    const itemFormClone = itemForm.children[0].cloneNode(true);
+    itemFormClone.children[1].setAttribute("name", `setlist[setlist_items_attributes][${count}][song_title]`);
+    itemFormClone.children[1].setAttribute("id", `setlist_setlist_items_attributes_${count}_song_title`);
+    console.log(itemFormClone);
+    setlistItemContainer.appendChild(itemFormClone);
   });
 
   function counter() {

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -1,6 +1,5 @@
-document.addEventListener("turbo:load", setupAddItemButton, console.log("turbo:load"));
-document.addEventListener("turbo:render", setupAddItemButton, console.log("turbo:render"));
-
+document.addEventListener("turbo:load", setupAddItemButton);
+document.addEventListener("turbo:render", setupAddItemButton);
 function setupAddItemButton() {
   let count = 0;
   console.log("セットリスト登録フォーム用js");

--- a/app/models/setlist_item.rb
+++ b/app/models/setlist_item.rb
@@ -1,7 +1,7 @@
 class SetlistItem < ApplicationRecord
   belongs_to :setlist
 
-  validates :song_title, presence: true
+  validates :song_title, presence: true, length: { minimum: 2 }
   validates :position, presence: true, numericality: { only_integer: true }
 
   def remove_empty_song_title

--- a/app/views/setlists/forms/_setlist_form.html.erb
+++ b/app/views/setlists/forms/_setlist_form.html.erb
@@ -4,5 +4,10 @@
 
     <%= render partial: "setlists/forms/setlist_item_form", locals: { i: i } %>
   <% end %>
-  <%= f.submit "登録", class: "btn btn-primary" %>
+  <button id="add_setlist_item" type="button" class="btn btn-secondary mb-4">
+    曲を追加
+  </button>
+  <div>
+    <%= f.submit "登録", class: "btn btn-primary" %>
+  </div>
 <% end %>

--- a/app/views/setlists/forms/_setlist_form.html.erb
+++ b/app/views/setlists/forms/_setlist_form.html.erb
@@ -1,9 +1,12 @@
 <%= form_with model: setlist, local: true do |f| %>
   <%= render partial: "shared/error_message", locals: { model: setlist } %>
-  <%= f.fields_for :setlist_items do |i| %>
 
-    <%= render partial: "setlists/forms/setlist_item_form", locals: { i: i } %>
-  <% end %>
+  <div id="setlist_items_container">
+    <%= f.fields_for :setlist_items do |i| %>
+      <%= render partial: "setlists/forms/setlist_item_form", locals: { i: i } %>
+    <% end %>
+  </div>
+
   <button id="add_setlist_item" type="button" class="btn btn-secondary mb-4">
     曲を追加
   </button>

--- a/app/views/setlists/forms/_setlist_form.html.erb
+++ b/app/views/setlists/forms/_setlist_form.html.erb
@@ -7,6 +7,12 @@
     <% end %>
   </div>
 
+  <div id="template_setlist_item" style="display: none;">
+    <%= f.fields_for :setlist_items, SetlistItem.new, child_index: "new_record" do |builder| %>
+      <%= render partial: "setlists/forms/setlist_item_form", locals: { i: builder } %>
+    <% end %>
+  </div>
+
   <button id="add_setlist_item" type="button" class="btn btn-secondary mb-4">
     曲を追加
   </button>


### PR DESCRIPTION
## 本プルリクエストの概要
追加ボタンでアイテムフォームを動的に実装できるようにしました。

## 本プルリクエストの詳細
* 「曲を追加」ボタンによるアイテムフォームの表示
  [![Image from Gyazo](https://i.gyazo.com/a373af23a6bb2df0cfcb4d7014b88fc5.gif)](https://gyazo.com/a373af23a6bb2df0cfcb4d7014b88fc5)

## 本プルリクエストの実装で学んだこと
* 追加していくアイテムの実装方法
  * `style="display: none;"`で隠しテンプレートを作成
  * `cloneNode(true)`を使って要素のクローンを作成
  * `appendChild`を用いて表示
* Railsは6以降、`turbo`での部分的な画面遷移がデフォルトになっているため、`DOMContentLoaded`が想定通りに動作しないことがある。代わりに`turbo:load`（`turbo`によるページ全体のロード時）や`turbo:render`（部分的なコンテンツの更新時）などを用いる。