### PR TITLE
Fix セットリスト登録エラー時のcount修正

### DIFF
--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -1,7 +1,11 @@
 document.addEventListener("turbo:load", setupAddItemButton);
 document.addEventListener("turbo:render", setupAddItemButton);
 function setupAddItemButton() {
-  let count = 0;
+  const itemForms = document.querySelectorAll("[id^='setlist_setlist_items_attributes_'][id$='_song_title']");
+  const lastItemForm = itemForms[itemForms.length - 2];
+  const lastItemFormId = lastItemForm ? lastItemForm.id : null;
+  const lastItemFormIndex = lastItemFormId ? parseInt(lastItemFormId.match(/\d+/)[0]) : null;
+  let count = lastItemFormIndex;
   console.log("セットリスト登録フォーム用js");
   const addItemButton = document.getElementById("add_setlist_item");
   const setlistItemContainer = document.getElementById("setlist_items_container");
@@ -23,6 +27,7 @@ function setupAddItemButton() {
   // 「曲を追加」ボタンにイベントを設定
   addItemButton.addEventListener("click", () => {
     counter();
+    console.log("カウント", count);
     const itemFormClone = itemForm.children[0].cloneNode(true);
     itemFormClone.children[1].setAttribute("name", `setlist[setlist_items_attributes][${count}][song_title]`);
     itemFormClone.children[1].setAttribute("id", `setlist_setlist_items_attributes_${count}_song_title`);


### PR DESCRIPTION
## 本プルリクエストの概要
セットリスト登録エラー時の不具合を修正しました。

## 本プルリクエストの詳細
* （従来）
  セットリスト登録エラー時に、`count`が0になってしまう。
  →アイテムフォームを追加していくと、`setlist_setlist_items_attributes_1_song_title`が重複してしまい、データが送られない不具合につながっていた。
* （修正後）
  セットリスト登録エラー時に、idが`setlist_setlist_items_attributes_`で始まり`_song_title`で終わる要素を全て取得し、最後のフォームの数字部分を`count`に代入。これにより重複を避けることができる。

## 本プルリクエストの実装で学んだこと
* `querySelectorAll("[id^='xxx'][id$=yyy']");`のように書くことで、`id`が`xxx`で始まり、`yyy`で終わる要素を全て取得できる。