### PR TITLE
Feat 編集ページ実装

### DIFF
--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -26,6 +26,17 @@ class SetlistsController < ApplicationController
 
   def update
     @setlist = Setlist.find(params[:id])
+    # パラメータに含まれていない setlist_items は削除する
+    ids_for_update = Array.new
+    params[:setlist][:setlist_items_attributes].each do |_, item|
+      ids_for_update << item[:id] if item[:id].present?
+    end
+    @setlist.setlist_items.each_with_index do |item|
+      if item.id.present? && !ids_for_update.include?(item.id.to_s)
+        item.mark_for_destruction
+        Rails.logger.info "削除しました"
+      end
+    end
     if @setlist.update(setlist_params)
       flash[:success] = "セットリストを更新しました。"
       redirect_to setlists_path

--- a/app/javascript/customs/example.js
+++ b/app/javascript/customs/example.js
@@ -31,6 +31,10 @@ function initializeExamples() {
 
 function initializeDeleteButtons() {
   const examplesContainer = document.getElementById("examples-container");
+  if (!examplesContainer) {
+    console.log("examplesContainerが見つかりません");
+    return;
+  }
   examplesContainer.addEventListener("click", (event) => {
     console.log(event.target);
     if (event.target.id.startsWith("delete-example")) {

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -1,78 +1,64 @@
-document.addEventListener("turbo:load", setupRemoveButton);
+// document.addEventListener("turbo:load", setupRemoveButton);
+// document.addEventListener("turbo:load", setupAddItemButton);
+// document.addEventListener("turbo:render", setupRemoveButton);
+// document.addEventListener("turbo:render", setupAddItemButton);
+
 document.addEventListener("turbo:load", setupAddItemButton);
-document.addEventListener("turbo:render", setupRemoveButton);
+document.addEventListener("turbo:load", setupRemoveButton);
 document.addEventListener("turbo:render", setupAddItemButton);
-
-function setupAddItemButton() {
-  const itemForms = document.querySelectorAll("[id^='setlist_setlist_items_attributes_'][id$='_song_title']");
-  const lastItemForm = itemForms[itemForms.length - 2];
-  const lastItemFormId = lastItemForm ? lastItemForm.id : null;
-  const lastItemFormIndex = lastItemFormId ? parseInt(lastItemFormId.match(/\d+/)[0]) : null;
-  let count = lastItemFormIndex;
-  console.log("セットリスト登録フォーム用js");
-  const addItemButton = document.getElementById("add_setlist_item");
-  const setlistItemContainer = document.getElementById("setlist_items_container");
-  const itemForm = document.getElementById("template_setlist_item");
-
-  if (!addItemButton || !setlistItemContainer || !itemForm) {
-    console.log("必要な要素が見つかりません");
-    return;
-  }
-
-  if (addItemButton.getAttribute("id") === "add_item_button") {
-    console.log("ボタンがすでに設定されています");
-    return;
-  } else {
-    console.log("ボタンが設定されていません");
-    addItemButton.setAttribute("id", "add_item_button");
-  }
-
-  // 「曲を追加」ボタンにイベントを設定
-  addItemButton.addEventListener("click", () => {
-    counter();
-    console.log("カウント", count);
-    const itemFormClone = itemForm.children[0].cloneNode(true);
-    itemFormClone.children[1].setAttribute("name", `setlist[setlist_items_attributes][${count}][song_title]`);
-    itemFormClone.children[1].setAttribute("id", `setlist_setlist_items_attributes_${count}_song_title`);
-
-    const removeButton = itemFormClone.querySelector("[id^='remove_setlist_item']");
-    removeButton.setAttribute("id", `remove_setlist_item_${count}`);
-    removeButton.addEventListener("click", (event) => {
-      event.preventDefault();
-      const itemFormToRemove = removeButton.parentElement;
-      itemFormToRemove.remove();
-      console.log("削除ボタンが押されました");
-    });
-    console.log(itemFormClone);
-    setlistItemContainer.appendChild(itemFormClone);
-  });
-
-  function counter() {
-    count++;
-    return count;
-  }
-};
+document.addEventListener("turbo:render", setupRemoveButton);
+document.addEventListener("turbo:render", cleanupItemFormIDs);
 
 function setupRemoveButton() {
-  console.log("removeButton");
-  const removeButtons = document.querySelectorAll("[id^='remove_setlist_item_']");
-  removeButtons.forEach((removeButton, index) => {
-    if (removeButton.getAttribute("id") === `remove_setlist_item_${index}`) {
-      console.log("ボタンがすでに設定されています");
+  const setlistItemsContainer = document.getElementById("setlist_items_container");
+  if (!setlistItemsContainer) {
+    console.log("セットリスト登録において必要な要素が見つかりません");
+    return;
+  }
+
+  setlistItemsContainer.addEventListener("click", (event) => {
+    if (event.target.id.startsWith("remove_setlist_item_")) {
+      event.preventDefault();
+      const itemFormToRemove = event.target.parentElement;
+      itemFormToRemove.remove();
+      cleanupItemFormIDs();
+    } else {
+      console.log("削除ボタンが無効かも！");
+    }
+  });
+}
+
+function setupAddItemButton() {
+  const addButton = document.getElementById("add_setlist_item");
+  const setlistItemsContainer = document.getElementById("setlist_items_container");
+  const itemFormTemplate = document.getElementById("template_setlist_item");
+
+  if (!addButton || !setlistItemsContainer || !itemFormTemplate) {
+    console.log("セットリスト登録において必要な要素が見つかりません");
+    return;
+  }
+
+  addButton.addEventListener("click", () => {
+    const itemFormClone = itemFormTemplate.children[0].cloneNode(true);
+    itemFormClone.children[1].setAttribute("id", "setlist_setlist_items_attributes__song_title");
+    setlistItemsContainer.appendChild(itemFormClone);
+    cleanupItemFormIDs();
+  });
+}
+
+function cleanupItemFormIDs() {
+  const setlistItemForms = document.querySelectorAll('[id^="setlist_setlist_items_attributes_"][id$="_song_title"]');
+  if (setlistItemForms.length === 0) {
+    console.log("セットリストアイテムフォームが見つかりません");
+    return;
+  }
+
+  setlistItemForms.forEach((form, index) => {
+    if (setlistItemForms.length === index + 1) {
+      console.log("templateのため処理をスキップ");
       return;
     }
-    removeButton.setAttribute("id", `remove_setlist_item_${index}`);
-    removeButton.addEventListener("click", (event) => {
-      event.preventDefault();
-      const itemFormToRemove = removeButton.parentElement;
-      itemFormToRemove.remove();
-
-      const idFormToRemove = document.getElementById(`setlist_setlist_items_attributes_${index}_id`);
-      if (idFormToRemove) {
-        console.log("idFormToRemove", idFormToRemove);
-        idFormToRemove.remove();
-      }
-      console.log("削除ボタンが押されました");
-    });
+    form.setAttribute("id", `setlist_setlist_items_attributes_${index}_song_title`)
+    form.setAttribute("name", `setlist[setlist_items_attributes][${index}][song_title]`)
   });
-};
+}

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -11,6 +11,23 @@ document.addEventListener("turbo:render", setupAddItemButton);
 document.addEventListener("turbo:render", setupRemoveButton);
 document.addEventListener("turbo:render", cleanupItemFormIDs);
 
+function setupAddItemButton() {
+  const addButtonContainer = document.getElementById("add-button-container");
+  if (!addButtonContainer) {
+    console.log("セットリスト登録において必要な要素が見つかりません");
+    return;
+  }
+  console.log("setupAddItemButtonが呼ばれました");
+  addButtonContainer.addEventListener("click", (event) => {
+    console.log("setupAddItemButtonのイベントが発火しました");
+    if (event.target.id === "add_setlist_item") {
+      event.preventDefault();
+      addSetlistItemForm();
+    }
+  });
+  addButtonContainer.setAttribute("id", "setup-add-button-container");
+}
+
 function setupRemoveButton() {
   const setlistItemsContainer = document.getElementById("setlist_items_container");
   if (!setlistItemsContainer) {
@@ -28,23 +45,6 @@ function setupRemoveButton() {
       console.log("削除ボタンが無効かも！");
     }
   });
-}
-
-function setupAddItemButton() {
-  const addButtonContainer = document.getElementById("add-button-container");
-  if (!addButtonContainer) {
-    console.log("セットリスト登録において必要な要素が見つかりません");
-    return;
-  }
-  console.log("setupAddItemButtonが呼ばれました");
-  addButtonContainer.addEventListener("click", (event) => {
-    console.log("setupAddItemButtonのイベントが発火しました");
-    if (event.target.id === "add_setlist_item") {
-      event.preventDefault();
-      addSetlistItemForm();
-    }
-  });
-  addButtonContainer.setAttribute("id", "setup-add-button-container");
 }
 
 function cleanupItemFormIDs() {

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -5,6 +5,8 @@
 
 document.addEventListener("turbo:load", setupAddItemButton);
 document.addEventListener("turbo:load", setupRemoveButton);
+document.addEventListener("turbo:load", cleanupItemFormIDs);
+document.addEventListener("turbo:load", moveHiddenSetlistItemForm);
 document.addEventListener("turbo:render", setupAddItemButton);
 document.addEventListener("turbo:render", setupRemoveButton);
 document.addEventListener("turbo:render", cleanupItemFormIDs);
@@ -60,6 +62,19 @@ function cleanupItemFormIDs() {
     form.setAttribute("id", `setlist_setlist_items_attributes_${index}_song_title`)
     form.setAttribute("name", `setlist[setlist_items_attributes][${index}][song_title]`)
   });
+
+  const setlistItemIds = document.querySelectorAll('[id^="setlist_item_"]');
+  if (setlistItemIds.length === 0) {
+    console.log("セットリストアイテムIDが見つかりません");
+    return;
+  }
+  setlistItemIds.forEach((item, index) => {
+    if (setlistItemIds.length === index + 1) {
+      console.log("templateのため処理をスキップ");
+      return;
+    }
+    item.setAttribute("id", `setlist_item_${index}`);
+  });
 }
 
 function addSetlistItemForm() {
@@ -73,4 +88,25 @@ function addSetlistItemForm() {
   itemFormClone.children[1].setAttribute("id", "setlist_setlist_items_attributes__song_title");
   container.appendChild(itemFormClone);
   cleanupItemFormIDs();
+}
+
+function moveHiddenSetlistItemForm(){
+  const hidden_forms = document.querySelectorAll('[id^="setlist_setlist_items_attributes_"][id$="_id"]');
+  if (hidden_forms.length === 0) {
+    console.log("隠しフォームが見つかりません");
+    return;
+  }
+  hidden_forms.forEach((form, index) => {
+    // formのsetlist_setlist_items_attributes_と_idの間の部分を取得
+    const id = form.id.split("_").slice(4, -1).join("_");
+    const parentDiv = document.getElementById(`setlist_item_${id}`);
+    if (!parentDiv) {
+      console.log("親要素が見つかりません");
+      return;
+    }
+    const childrenClone = form.cloneNode(true);
+    console.log(childrenClone);
+    parentDiv.appendChild(childrenClone);
+    form.remove();
+  });
 }

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -29,21 +29,20 @@ function setupRemoveButton() {
 }
 
 function setupAddItemButton() {
-  const addButton = document.getElementById("add_setlist_item");
-  const setlistItemsContainer = document.getElementById("setlist_items_container");
-  const itemFormTemplate = document.getElementById("template_setlist_item");
-
-  if (!addButton || !setlistItemsContainer || !itemFormTemplate) {
+  const addButtonContainer = document.getElementById("add-button-container");
+  if (!addButtonContainer) {
     console.log("セットリスト登録において必要な要素が見つかりません");
     return;
   }
-
-  addButton.addEventListener("click", () => {
-    const itemFormClone = itemFormTemplate.children[0].cloneNode(true);
-    itemFormClone.children[1].setAttribute("id", "setlist_setlist_items_attributes__song_title");
-    setlistItemsContainer.appendChild(itemFormClone);
-    cleanupItemFormIDs();
+  console.log("setupAddItemButtonが呼ばれました");
+  addButtonContainer.addEventListener("click", (event) => {
+    console.log("setupAddItemButtonのイベントが発火しました");
+    if (event.target.id === "add_setlist_item") {
+      event.preventDefault();
+      addSetlistItemForm();
+    }
   });
+  addButtonContainer.setAttribute("id", "setup-add-button-container");
 }
 
 function cleanupItemFormIDs() {
@@ -61,4 +60,17 @@ function cleanupItemFormIDs() {
     form.setAttribute("id", `setlist_setlist_items_attributes_${index}_song_title`)
     form.setAttribute("name", `setlist[setlist_items_attributes][${index}][song_title]`)
   });
+}
+
+function addSetlistItemForm() {
+  const container = document.getElementById("setlist_items_container");
+  const itemFormTemplate = document.getElementById("template_setlist_item");
+  if (!container || !itemFormTemplate) {
+    console.log("フォーム追加のためのアイテムが見つかりません");
+    return;
+  }
+  const itemFormClone = itemFormTemplate.children[0].cloneNode(true);
+  itemFormClone.children[1].setAttribute("id", "setlist_setlist_items_attributes__song_title");
+  container.appendChild(itemFormClone);
+  cleanupItemFormIDs();
 }

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -41,6 +41,7 @@ function setupRemoveButton() {
       const itemFormToRemove = event.target.parentElement;
       itemFormToRemove.remove();
       cleanupItemFormIDs();
+      setupHiddenIdForms();
     } else {
       console.log("削除ボタンが無効かも！");
     }
@@ -108,5 +109,19 @@ function moveHiddenSetlistItemForm(){
     console.log(childrenClone);
     parentDiv.appendChild(childrenClone);
     form.remove();
+  });
+}
+
+function setupHiddenIdForms() {
+  const hiddenItemIds = document.querySelectorAll('[id^="setlist_setlist_items_attributes_"][id$="_id"]');
+  if (hiddenItemIds.length === 0) {
+    console.log("隠しフォームが見つかりません");
+    return;
+  }
+  hiddenItemIds.forEach((form) => {
+    const parentDiv = form.parentElement;
+    const id = parentDiv.id.split("_").slice(2).join("_");
+    form.setAttribute("id", `setlist_setlist_items_attributes_${id}_id`);
+    form.setAttribute("name", `setlist[setlist_items_attributes][${id}][id]`);
   });
 }

--- a/app/models/setlist.rb
+++ b/app/models/setlist.rb
@@ -15,8 +15,12 @@ class Setlist < ApplicationRecord
   end
 
   def set_position_to_items
-    setlist_items.each_with_index do |item, index|
-      item.position = index + 1
+    index = 1
+    setlist_items.each do |item|
+      # itemがmark_for_destructionされている場合はpositionを設定しない
+      next if item.marked_for_destruction?
+      item.position = index
+      index += 1
     end
   end
 end

--- a/app/models/setlist.rb
+++ b/app/models/setlist.rb
@@ -6,6 +6,19 @@ class Setlist < ApplicationRecord
   before_validation :filter_no_title_items
   before_validation :set_position_to_items
 
+  # remove_not_included_itemsの定義
+  def remove_not_included_items(ids_for_update)
+    setlist_items.each_with_index do |item, index|
+      # itemがmark_for_destructionされている場合は削除しない
+      next if item.marked_for_destruction?
+      # itemがparamsに含まれていない場合は削除する
+      unless ids_for_update.include?(item.id.to_s)
+        item.mark_for_destruction
+        Rails.logger.info "削除しました"
+      end
+    end
+  end
+
   private
 
   def filter_no_title_items

--- a/app/views/setlists/forms/_setlist_form.html.erb
+++ b/app/views/setlists/forms/_setlist_form.html.erb
@@ -13,9 +13,12 @@
     <% end %>
   </div>
 
-  <button id="add_setlist_item" type="button" class="btn btn-secondary mb-4">
-    曲を追加
-  </button>
+  <div id="add-button-container">
+    <button id="add_setlist_item" type="button" class="btn btn-secondary mb-4">
+      曲を追加
+    </button>
+  </div>
+
   <div>
     <%= f.submit "登録", class: "btn btn-primary" %>
   </div>

--- a/app/views/setlists/forms/_setlist_item_form.html.erb
+++ b/app/views/setlists/forms/_setlist_item_form.html.erb
@@ -1,4 +1,4 @@
-<div class="flex items-center mb-4">
+<div class="flex items-center mb-4" id="setlist_item_">
   <%= i.label :song_title, "曲名", class: "mr-4" %>
   <%= i.text_field :song_title, class: "input input-bordered w-full max-w-xs" %>
   <div class="ml-4 btn btn-neutral" id="remove_setlist_item_">


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示：このプルリクエストをレビューしてコメントする際には、日本語を使用してください。 -->

## 本プルリクエストの概要
編集ページを作成しました。

## 本プルリクエストの詳細
* `setlist_item`削除ボタン押下時の挙動変更


## 本プルリクエストの実装で学んだこと
* 編集ページでは、既存の子要素の近くに`<input... type="hidden" value="..." id="..._id">`が含まれている。ビュー上には現れないが、送信時に`{id=>...}`も送られる。