### PR TITLE
Add 新規・編集ページに順序変更ボタンを実装

### DIFF
--- a/app/controllers/setlists_controller.rb
+++ b/app/controllers/setlists_controller.rb
@@ -32,9 +32,6 @@ class SetlistsController < ApplicationController
       flash[:success] = "セットリストを更新しました。"
       redirect_to setlists_path
     else
-      p "=" * 50
-      p @setlist.errors.full_messages
-      p "=" * 50
       flash.now[:error] = "セットリストの更新に失敗しました。"
       render :edit, status: :unprocessable_entity
     end

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -43,6 +43,7 @@ function setupRemoveButton() {
       itemFormToRemove.remove();
       cleanupItemFormIDs();
       setupHiddenIdForms();
+      setupPositionForm();
     } else {
       console.log("削除ボタンが無効かも！");
     }
@@ -147,8 +148,6 @@ function setupArrowButtons() {
       }
       const parentDiv = itemFormToUp.parentElement;
       parentDiv.insertBefore(itemFormToUp, itemFormToDown);
-      cleanupItemFormIDs();
-      setupHiddenIdForms();
     } else if (event.target.id.startsWith("items_down")) {
       event.preventDefault();
       const itemFormToDown = event.target.parentElement;
@@ -160,8 +159,26 @@ function setupArrowButtons() {
       const parentDiv = itemFormToDown.parentElement;
       console.log("parentDiv", parentDiv);
       parentDiv.insertBefore(itemFormToUp, itemFormToDown);
-      cleanupItemFormIDs();
-      setupHiddenIdForms();
     }
+    cleanupItemFormIDs();
+    setupHiddenIdForms();
+    setupPositionForm();
   })
+}
+
+function setupPositionForm() {
+  const positionForms = document.querySelectorAll('[id^="setlist_setlist_items_attributes_"][id$="_position"]');
+  if (positionForms.length === 0) {
+    console.log("ポジションフォームが見つかりません");
+    return;
+  }
+  positionForms.forEach((form, index) => {
+    if (positionForms.length === index + 1) {
+      console.log("templateのため処理をスキップ");
+      return;
+    }
+    form.setAttribute("id", `setlist_setlist_items_attributes_${index}_position`);
+    form.setAttribute("name", `setlist[setlist_items_attributes][${index}][position]`);
+    form.value = index + 1;
+  });
 }

--- a/app/javascript/customs/setlist_form.js
+++ b/app/javascript/customs/setlist_form.js
@@ -26,6 +26,7 @@ function setupAddItemButton() {
     }
   });
   addButtonContainer.setAttribute("id", "setup-add-button-container");
+  setupArrowButtons();
 }
 
 function setupRemoveButton() {
@@ -124,4 +125,43 @@ function setupHiddenIdForms() {
     form.setAttribute("id", `setlist_setlist_items_attributes_${id}_id`);
     form.setAttribute("name", `setlist[setlist_items_attributes][${id}][id]`);
   });
+}
+
+function setupArrowButtons() {
+  const setlistItemsContainer = document.getElementById("setlist_items_container");
+  if (!setlistItemsContainer) {
+    console.log("セットリスト登録において必要な要素が見つかりません");
+    return;
+  }
+
+  setlistItemsContainer.addEventListener("click", (event) => {
+    console.log("setupArrowButtonsのイベントが発火しました");
+    console.log("event.target.id", event.target.id);
+    if (event.target.id.startsWith("items_up")) {
+      event.preventDefault();
+      const itemFormToUp = event.target.parentElement;
+      const itemFormToDown = itemFormToUp.previousElementSibling;
+      if (!itemFormToDown) {
+        console.log("上に移動できません");
+        return;
+      }
+      const parentDiv = itemFormToUp.parentElement;
+      parentDiv.insertBefore(itemFormToUp, itemFormToDown);
+      cleanupItemFormIDs();
+      setupHiddenIdForms();
+    } else if (event.target.id.startsWith("items_down")) {
+      event.preventDefault();
+      const itemFormToDown = event.target.parentElement;
+      const itemFormToUp = itemFormToDown.nextElementSibling;
+      if (!itemFormToUp) {
+        console.log("下に移動できません");
+        return;
+      }
+      const parentDiv = itemFormToDown.parentElement;
+      console.log("parentDiv", parentDiv);
+      parentDiv.insertBefore(itemFormToUp, itemFormToDown);
+      cleanupItemFormIDs();
+      setupHiddenIdForms();
+    }
+  })
 }

--- a/app/models/setlist.rb
+++ b/app/models/setlist.rb
@@ -1,5 +1,5 @@
 class Setlist < ApplicationRecord
-  has_many :setlist_items, dependent: :destroy, autosave: :true
+  has_many :setlist_items, -> {order(:position)}, dependent: :destroy, autosave: :true
   accepts_nested_attributes_for :setlist_items, allow_destroy: true, reject_if: :all_blank
 
   validates :setlist_items, presence: true

--- a/app/models/setlist.rb
+++ b/app/models/setlist.rb
@@ -4,7 +4,6 @@ class Setlist < ApplicationRecord
 
   validates :setlist_items, presence: true
   before_validation :filter_no_title_items
-  before_validation :set_position_to_items
 
   # remove_not_included_itemsの定義
   def remove_not_included_items(ids_for_update)
@@ -24,16 +23,6 @@ class Setlist < ApplicationRecord
   def filter_no_title_items
     setlist_items.each do |item|
       item.remove_empty_song_title
-    end
-  end
-
-  def set_position_to_items
-    index = 1
-    setlist_items.each do |item|
-      # itemがmark_for_destructionされている場合はpositionを設定しない
-      next if item.marked_for_destruction?
-      item.position = index
-      index += 1
     end
   end
 end

--- a/app/views/setlists/forms/_setlist_item_form.html.erb
+++ b/app/views/setlists/forms/_setlist_item_form.html.erb
@@ -1,6 +1,7 @@
 <div class="flex items-center mb-4" id="setlist_item_">
   <%= i.label :song_title, "曲名", class: "mr-4" %>
   <%= i.text_field :song_title, class: "input input-bordered w-full max-w-xs" %>
+  <%= i.hidden_field :position %>
   <i class="fa-solid fa-arrow-up ml-4 border-2 p-2 rounded-md" id="items_up_"></i>
   <i class="fa-solid fa-arrow-down ml-4 border-2 p-2 rounded-md" id="items_down_"></i>
   <div class="ml-4 btn btn-neutral" id="remove_setlist_item_">

--- a/app/views/setlists/forms/_setlist_item_form.html.erb
+++ b/app/views/setlists/forms/_setlist_item_form.html.erb
@@ -1,12 +1,8 @@
 <div class="flex items-center mb-4" id="setlist_item_">
   <%= i.label :song_title, "曲名", class: "mr-4" %>
   <%= i.text_field :song_title, class: "input input-bordered w-full max-w-xs" %>
-  <div class="ml-4 border-2 p-2 rounded-md" id="items_up_">
-    <i class="fa-solid fa-arrow-up"></i>
-  </div>
-  <div class="ml-4 border-2 p-2 rounded-md" id="items_down_">
-    <i class="fa-solid fa-arrow-down"></i>
-  </div>
+  <i class="fa-solid fa-arrow-up ml-4 border-2 p-2 rounded-md" id="items_up_"></i>
+  <i class="fa-solid fa-arrow-down ml-4 border-2 p-2 rounded-md" id="items_down_"></i>
   <div class="ml-4 btn btn-neutral" id="remove_setlist_item_">
     削除
   </div>

--- a/app/views/setlists/forms/_setlist_item_form.html.erb
+++ b/app/views/setlists/forms/_setlist_item_form.html.erb
@@ -1,6 +1,12 @@
 <div class="flex items-center mb-4" id="setlist_item_">
   <%= i.label :song_title, "曲名", class: "mr-4" %>
   <%= i.text_field :song_title, class: "input input-bordered w-full max-w-xs" %>
+  <div class="ml-4 border-2 p-2 rounded-md" id="items_up_">
+    <i class="fa-solid fa-arrow-up"></i>
+  </div>
+  <div class="ml-4 border-2 p-2 rounded-md" id="items_down_">
+    <i class="fa-solid fa-arrow-down"></i>
+  </div>
   <div class="ml-4 btn btn-neutral" id="remove_setlist_item_">
     削除
   </div>


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示：このプルリクエストをレビューしてコメントする際には、日本語を使用してください。 -->

## 本プルリクエストの概要
新規・編集ページに、`setlist_item`の順序変更ボタンを実装しました。

## 本プルリクエストの詳細
* 矢印ボタンの表示・順序変更動作の実装
  [![Image from Gyazo](https://i.gyazo.com/74180a2dd3020fa0d1a0877a7e6e9bcf.gif)](https://gyazo.com/74180a2dd3020fa0d1a0877a7e6e9bcf)
* `position`カラムの値を保持する隠しinputフォームの実装・動的な値の変更実装


## 本プルリクエストの実装で学んだこと
* jsにおける`insertBefore`の使い方。`親要素.insertBefore(追加対象, どの要素の上に置くか);`
* `has_many`で設定している子要素の、デフォルト順序の設定方法。`has_many :setlist_items, -> {order(:position)}`